### PR TITLE
docs: Fix a few typos

### DIFF
--- a/MiscFunctions.py
+++ b/MiscFunctions.py
@@ -46,7 +46,7 @@ class debouncer(object):  #Takes a binary "signal" and debounces it.
     def signal(self, value):  #Update the signal.
         if value != self.state:  #We are receiving a different signal than what we have been.
             self.opposite_counter = self.opposite_counter + 1
-        else:  #We are recieving the same signal that we have been
+        else:  #We are receiving the same signal that we have been
             self.opposite_counter = self.opposite_counter - 1
 
         if self.opposite_counter < 0: self.opposite_counter = 0
@@ -100,7 +100,7 @@ def has_thumb(hand):  #The level of accuracy with this function is surprisingly 
     average = sum(distances)/len(distances)
     minimum = min(distances)
     if average - minimum > 20:  #Check if the finger closest to the palm is more than 20mm closer than the average distance
-        #Note: I have recieved feedback that a smaller value may work better. I do have big hands, however
+        #Note: I have received feedback that a smaller value may work better. I do have big hands, however
         return True
     else:
         return False

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Movements are associated with commands listed in a file `commands.ini` placed at
     4finger: rhythmbox-client --pause
     5finger: rhythmbox-client --pause
 
-Every commands could have a different behaviour if 1, 2, 3 ... 10 fingers are recognized but It's recommanded to use the same command for each number of fingers due to a lack of precision with Leap Motion.
+Every commands could have a different behaviour if 1, 2, 3 ... 10 fingers are recognized but It's recommended to use the same command for each number of fingers due to a lack of precision with Leap Motion.
 
 ###Notes:
 This is a spare-time project, so it's not perfect quality. However, I tried to keep the code clean and readable. Let me know if you find any bugs (which there are certainly at least a few of).


### PR DESCRIPTION
There are small typos in:
- MiscFunctions.py
- README.md

Fixes:
- Should read `recommended` rather than `recommanded`.
- Should read `receiving` rather than `recieving`.
- Should read `received` rather than `recieved`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md